### PR TITLE
Fix typo, update Gradle refs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ATOPizzaFactory.ToolKit.Java
 
-A modular Java library developed for playground, learning and demo porpoises.
+A modular Java library developed for playground, learning and demo purposes.
 
 
 ## Build Tool (Gradle)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,7 +3,7 @@
  *
  * This generated file contains a sample Java library project to get you started.
  * For more details take a look at the 'Building Java & JVM projects' chapter in the Gradle
- * User Manual available at https://docs.gradle.org/8.0.2/userguide/building_java_projects.html
+ * User Manual available at https://docs.gradle.org/8.7/userguide/building_java_projects.html
  */
 
 plugins {
@@ -47,7 +47,7 @@ publishing {
 }
 
 
-// $ ./gradlew wrapper --gradle-version 8.0.2 --distribution-type all
+// $ ./gradlew wrapper --gradle-version 8.7 --distribution-type all
 //tasks.register('wrapper', Wrapper) {
 //    gradleVersion = '8.7'
 //}

--- a/core/src/test/java/ato_pizza_factory/tool_kit/core/models/RoundPizzaTest.java
+++ b/core/src/test/java/ato_pizza_factory/tool_kit/core/models/RoundPizzaTest.java
@@ -2,52 +2,18 @@ package ato_pizza_factory.tool_kit.core.models;
 
 import ato_pizza_factory.tool_kit.core.exceptions.PizzaObjectException;
 import ato_pizza_factory.tool_kit.core.models.components.PizzaSize;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RoundPizzaTest {
 
-    @Test
-    void test_BuildPersonalRoundPizza_HappyPath() throws PizzaObjectException {
-        RoundPizza thePizza = new RoundPizza(PizzaSize.PERSONAL);
+    @ParameterizedTest
+    @EnumSource(value = PizzaSize.class, names = {"CUSTOM"}, mode = EnumSource.Mode.EXCLUDE)
+    void test_BuildRoundPizza_HappyPath(PizzaSize pizzaSize) throws PizzaObjectException {
+        RoundPizza thePizza = new RoundPizza(pizzaSize);
 
-        assertEquals(PizzaSize.PERSONAL, thePizza.getSize(), "A PERSONAL size round pizza was created...");
+        assertEquals(pizzaSize, thePizza.getSize(), "A " + pizzaSize + " size round pizza was created...");
     }
-
-    @Test
-    void test_BuildSmallRoundPizza_HappyPath() throws PizzaObjectException {
-        RoundPizza thePizza = new RoundPizza(PizzaSize.SMALL);
-
-        assertEquals(PizzaSize.SMALL, thePizza.getSize(), "A SMALL size round pizza was created...");
-    }
-
-    @Test
-    void test_BuildMediumRoundPizza_HappyPath() throws PizzaObjectException {
-        RoundPizza thePizza = new RoundPizza(PizzaSize.MEDIUM);
-
-        assertEquals(PizzaSize.MEDIUM, thePizza.getSize(), "A MEDIUM size round pizza was created...");
-    }
-
-    @Test
-    void test_BuildLargeRoundPizza_HappyPath() throws PizzaObjectException {
-        RoundPizza thePizza = new RoundPizza(PizzaSize.LARGE);
-
-        assertEquals(PizzaSize.LARGE, thePizza.getSize(), "A LARGE size round pizza was created...");
-    }
-
-    @Test
-    void test_BuildFamilyRoundPizza_HappyPath() throws PizzaObjectException {
-        RoundPizza thePizza = new RoundPizza(PizzaSize.FAMILY);
-
-        assertEquals(PizzaSize.FAMILY, thePizza.getSize(), "A FAMILY size round pizza was created...");
-    }
-
-    @Test
-    void test_BuildTheBeastRoundPizza_HappyPath() throws PizzaObjectException {
-        RoundPizza thePizza = new RoundPizza(PizzaSize.THE_BEAST);
-
-        assertEquals(PizzaSize.THE_BEAST, thePizza.getSize(), "A THE_BEAST size round pizza was created...");
-    }
-
 }

--- a/core/src/test/java/ato_pizza_factory/tool_kit/core/utils/PizzaValidatorUtilTest.java
+++ b/core/src/test/java/ato_pizza_factory/tool_kit/core/utils/PizzaValidatorUtilTest.java
@@ -5,6 +5,9 @@ import ato_pizza_factory.tool_kit.core.models.components.PizzaSize;
 import ato_pizza_factory.tool_kit.core.models.IPizza;
 import ato_pizza_factory.tool_kit.core.models.PizzaCode;
 import ato_pizza_factory.tool_kit.core.models.RoundPizza;
+import ato_pizza_factory.tool_kit.core.models.components.SizeMetric;
+import ato_pizza_factory.tool_kit.core.models.components.SizeReference;
+import ato_pizza_factory.tool_kit.core.models.components.SizeValue;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,18 +37,22 @@ class PizzaValidatorUtilTest {
 
     @Test
     void test_PizzaValidatorUtil_validateCustomSizeInRange_HappyPath() throws PizzaObjectException {
-        IPizza thePizza = new RoundPizza(PizzaSize.PERSONAL);
+        IPizza thePizza = new RoundPizza(20);
 
-        assertEquals(PizzaSize.PERSONAL, thePizza.getSize(), "A PERSONAL size round pizza was created...");
+        assertEquals(PizzaSize.CUSTOM, thePizza.getSize());
 
-        assertDoesNotThrow(() -> PizzaValidatorUtil.validateNonNullPizzaObject(thePizza), "The pizza object is not null...");
+        assertDoesNotThrow(() -> PizzaValidatorUtil.validateCustomSizeInRange(thePizza),
+                "The custom pizza size is within the allowed range...");
     }
 
     @Test
     void test_PizzaValidatorUtil_validateCustomSizeInRange_ToShortException() throws PizzaObjectException {
-        PizzaObjectException theException;
+        IPizza thePizza = new RoundPizza(20);
+        // tamper the size to be invalid
+        thePizza.getSizeValues().put(SizeReference.DIAMETER, new SizeValue(1, SizeMetric.CM));
 
-        theException = assertThrows(PizzaObjectException.class, () -> PizzaValidatorUtil.validateNonNullPizzaObject(new RoundPizza(1)), "The pizza object to short...");
+        PizzaObjectException theException = assertThrows(PizzaObjectException.class,
+                () -> PizzaValidatorUtil.validateCustomSizeInRange(thePizza), "The pizza object too short...");
 
         assertNotNull(theException, "An exception was thrown...");
         assertEquals(PizzaObjectException.class, theException.getClass());
@@ -55,9 +62,12 @@ class PizzaValidatorUtilTest {
 
     @Test
     void test_PizzaValidatorUtil_validateCustomSizeInRange_ToLongException() throws PizzaObjectException {
-        PizzaObjectException theException;
+        IPizza thePizza = new RoundPizza(20);
+        // tamper the size to be invalid
+        thePizza.getSizeValues().put(SizeReference.DIAMETER, new SizeValue(1000, SizeMetric.CM));
 
-        theException = assertThrows(PizzaObjectException.class, () -> PizzaValidatorUtil.validateNonNullPizzaObject(new RoundPizza(1000)), "The pizza object to long...");
+        PizzaObjectException theException = assertThrows(PizzaObjectException.class,
+                () -> PizzaValidatorUtil.validateCustomSizeInRange(thePizza), "The pizza object too long...");
 
         assertNotNull(theException, "An exception was thrown...");
         assertEquals(PizzaObjectException.class, theException.getClass());

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@
  * The settings file is used to specify which projects to include in your build.
  *
  * Detailed information about configuring a multi-project build in Gradle can be found
- * in the user manual at https://docs.gradle.org/8.0.2/userguide/multi_project_builds.html
+ * in the user manual at https://docs.gradle.org/8.7/userguide/multi_project_builds.html
  */
 
 rootProject.name = 'ATOPizzaFactory.ToolKit'


### PR DESCRIPTION
## Summary
- fix "demo porpoises" typo in README
- update generated Gradle comments to reference 8.7
- refactor `RoundPizzaTest` into a parameterized test
- correct `PizzaValidatorUtilTest` to test `validateCustomSizeInRange`

## Testing
- `gradle test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6866903ec44883278cf319cc695fc775