### PR TITLE
Update README with test and publish instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,26 @@ $ ./gradlew -v
 Gradle 8.7
 ...
 ```
+
+## Running Tests
+
+To execute the unit tests run:
+
+```bash
+./gradlew test
+```
+
+If the dependencies were previously downloaded you can run offline:
+
+```bash
+./gradlew test --offline
+```
+
+## Publishing Artifacts
+
+Publishing is disabled by default. To publish to the configured Maven
+repository you must explicitly allow it:
+
+```bash
+./gradlew publish -PallowPublish=true
+```


### PR DESCRIPTION
## Summary
- add sections documenting how to run tests and publish artifacts with the new allowPublish flag
- mention offline mode for running tests

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: Unable to download gradle due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686c3b946d988327a15cdccbdb544d3b